### PR TITLE
Propose/dds over http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "yaml.schemas": {
-        "openapi:v3": "file:///home/mike/project/dcs_standards/source/dds-http.yaml"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "openapi:v3": "file:///home/mike/project/dcs_standards/source/dds-http.yaml"
+    }
+}

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -1,0 +1,38 @@
+openapi: '3.0.2'
+info:
+  title: DDS over HTTP
+  version: '1.0'
+servers:
+  - url: http://localhost
+
+components:
+  responses:
+    '500':
+      description: This will be returned on server error. It is up to the client to decide how to try connecting again.
+    '503':
+      description: Inform clients that the system is shutting down or other-wise not ready yet.
+      headers:
+        retry-after:
+          description: When to try connecting again.
+          required: false
+          type: string
+  schemas:
+    criteria:
+      type: object
+      properties:
+        medium-id-mask:
+          type: string
+          description: Regular expression to identify what transport medium messages to include
+paths:
+  /feed:
+    get:
+      responses:
+        '200':
+          description: Reponse includes any data available.
+        '204':
+          description: No new data available, request again.
+        '500':
+          $ref: '#/components/responses/500'
+        '503':
+          $ref: '#/components/responses/503'
+      description: Retrieve message for the given, or all if none provided, criteria. This uses HTTP long-polling. After 9 seconds, if no new data is available from the server a 204 Response is sent to the client to indicate the client should connect again to wait for more data.

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -13,9 +13,10 @@ components:
       description: Inform clients that the system is shutting down or other-wise not ready yet.
       headers:
         retry-after:
-          description: When to try connecting again.
+          description: When to try connecting again. Sending this header to clients is optional.
           required: false
-          type: string
+          schema:
+            type: string
   schemas:
     criteria:
       type: object
@@ -24,8 +25,17 @@ components:
           type: string
           description: Regular expression to identify what transport medium messages to include
 paths:
-  /feed:
+  /data:
     get:
+      summary: Retrieve DCS data
+      parameters:
+        - name: criteria
+          in: query
+          description: Name of previously provided criteria to use
+          required: false
+          schema:
+            type: string
+            description: Alphanumeric string given when the critirea was saved.
       responses:
         '200':
           description: Reponse includes any data available.
@@ -36,3 +46,21 @@ paths:
         '503':
           $ref: '#/components/responses/503'
       description: Retrieve message for the given, or all if none provided, criteria. This uses HTTP long-polling. After 9 seconds, if no new data is available from the server a 204 Response is sent to the client to indicate the client should connect again to wait for more data.
+  /criteria:
+    post:
+      summary: Provide creteria for limiting data returned.
+      description: Allows the client to inform the system exactly which data should be returned.
+      responses:
+        '201':
+          description: "Sucessfully stored."
+        '400':
+          description: "Error saving criteria."
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/criteria'
+

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -1,7 +1,8 @@
 openapi: '3.0.2'
 info:
   title: DDS over HTTP
-  version: '1.0'
+  version: '1.0.0'
+  description: Defines bare minimum requirements for exchanging 
 servers:
   - url: http://localhost
 
@@ -24,8 +25,60 @@ components:
         medium-id-mask:
           type: string
           description: Regular expression to identify what transport medium messages to include
+        since:
+          type: string
+        until:
+          type: string          
+    dcpMessage:
+      type: object
+      properties:
+        receiveTime:
+          type: string
+          format: date-time
+        dataSource:
+          $ref: "#/components/schemas/dataSource"
+        data:
+          description: Base64 encoded version of the data. May be text or binary. Messages should
+                       be processed based on the type
+          type: string
+          format: byte
+    dcpMessages:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Number of messages contained in this result
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/dcpMessage'
+    dataSource:
+      description: Source of data that this system retrieves messages from.
+                   A given source has a name and type and may provide additional properties as appropriate.
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          $ref: "#/components/schemas/dataSourceType"
+      required:
+        - name
+        - type
+      additionalProperties: true
+    knownSourceTypes:
+      type: string
+      enum: ["GOES", "Iridium", "Network Dcp", "HRIT", "DRGS", "LRGS", "NOAPORT", "WEB"]
+    customSourceType:
+      type: string
+    dataSourceType:
+      description: An LRGS generally processes data from specific known sources; however it is possible
+                   for a given installation to retrieve data from custom sources.
+      oneOf:
+        - $ref: '#/components/schemas/knownSourceTypes'
+        - $ref: '#/components/schemas/customSourceType'
+        
 paths:
-  /data:
+  /dds/data/next:
     get:
       summary: Retrieve DCS data
       parameters:
@@ -35,10 +88,14 @@ paths:
           required: false
           schema:
             type: string
-            description: Alphanumeric string given when the critirea was saved.
+            description: Alphanumeric string given when the criteria was provided to the server.
       responses:
         '200':
-          description: Reponse includes any data available.
+          description: Response includes any data available.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dcpMessages'
         '204':
           description: No new data available, request again.
         '500':
@@ -46,15 +103,15 @@ paths:
         '503':
           $ref: '#/components/responses/503'
       description: Retrieve message for the given, or all if none provided, criteria. This uses HTTP long-polling. After 9 seconds, if no new data is available from the server a 204 Response is sent to the client to indicate the client should connect again to wait for more data.
-  /criteria:
+  /dds/data/search:
     post:
-      summary: Provide creteria for limiting data returned.
+      summary: Provide criteria for limiting data returned.
       description: Allows the client to inform the system exactly which data should be returned.
       responses:
         '201':
-          description: "Sucessfully stored."
+          description: "Successfully stored."
         '400':
-          description: "Error saving criteria."
+          description: "Provided criteria is invalid."
         '500':
           $ref: '#/components/responses/500'
       requestBody:
@@ -63,4 +120,16 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/criteria'
-
+  /dds/sources:
+    get:
+      summary: Provide information about data sources available from this instance
+      description: Allow client to know what data sources are available
+      responses:
+        '200':
+          description: Sources successfully sent to user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/dataSource"

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -4,7 +4,7 @@ info:
   version: '1.0.0'
   description: Defines bare minimum requirements for exchanging 
 servers:
-  - url: /api/dds
+  - url: /dds
     description: USACE LRGS DDS Server
 
 components:

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -388,12 +388,12 @@ paths:
           $ref: '#/components/responses/503'
   /data/summary:
     get:
-      summary: Retrieve status summary for a group
+      summary: Retrieve status summary for a group DCPs
       description: |
         Returns a summarized status report for a group of DCP locations, including message counts,
         parity errors, and battery health.
       parameters:
-        - name: group
+        - name: data-group
           in: query
           required: true
           description: The name of the group to summarize (e.g., "SWT")

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -250,7 +250,7 @@ components:
                 type: boolean
     
 paths:
-  /dds/data/next:
+  /data/next:
     get:
       summary: Retrieve DCS data
       parameters:
@@ -275,7 +275,7 @@ paths:
         '503':
           $ref: '#/components/responses/503'
       description: Retrieve message for the given, or all if none provided, criteria. This uses HTTP long-polling. After 9 seconds, if no new data is available from the server a 204 Response is sent to the client to indicate the client should connect again to wait for more data.
-  /dds/data/search:
+  /data/search:
     post:
       summary: Provide criteria for limiting data returned.
       description: Allows the client to inform the system exactly which data should be returned.
@@ -293,7 +293,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/searchCriteria'
-  /dds/sources:
+  /sources:
     get:
       summary: Provide information about data sources available from this instance
       description: Allow client to know what data sources are available
@@ -310,7 +310,7 @@ paths:
           $ref: '#/components/responses/500'
       tags:
         - sources
-  /dds/data/query:
+  /data/query:
     get:
       summary: Query DCP messages on the fly
       description: |
@@ -387,7 +387,7 @@ paths:
           $ref: '#/components/responses/500'
         '503':
           $ref: '#/components/responses/503'
-  /dds/data/summary:
+  /data/summary:
     get:
       summary: Retrieve status summary for a group
       description: |

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -4,7 +4,7 @@ info:
   version: '1.0.0'
   description: Defines bare minimum requirements for exchanging 
 servers:
-  - url: https://lrgs.usace.army.mil/api
+  - url: /api/dds
     description: USACE LRGS DDS Server
 
 components:
@@ -207,6 +207,7 @@ components:
     statusGroupSummary:
       type: object
       description: Summary of DCP statuses for a group of locations
+      additionalProperties: true
       properties:
         timestamp:
           type: string
@@ -225,13 +226,6 @@ components:
               type: integer
             complete:
               type: integer
-            reservoir:
-              type: integer
-        lowBatteryAddresses:
-          type: array
-          items:
-            type: string
-          description: List of DCP addresses with low battery status
         locations:
           type: object
           additionalProperties:
@@ -251,6 +245,7 @@ components:
                 type: integer
                 description: Number of parity message issues
               lowBattery:
+                description: List of DCP addresses with low battery status
                 type: boolean
     
 paths:

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -1,7 +1,9 @@
 openapi: '3.0.2'
 info:
   title: DDS over HTTP
-  version: '1.0.0'
+  # will update to 1.0.0 once We have better stablized on the design 
+  # after some usages.
+  version: '0.0.1'
   description: |
   **DCP Data Service (DDS) over HTTP**
     

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -2,7 +2,10 @@ openapi: '3.0.2'
 info:
   title: DDS over HTTP
   version: '1.0.0'
-  description: Defines bare minimum requirements for exchanging 
+  description: |
+  **DCP Data Service (DDS) over HTTP**
+    
+   This API defines the minimum URL requirements for exchanging Data Collection Platform (DCP) messages over HTTP. It defines access to telemetry data collected from multiple sources including GOES and Iridium satellites, and other data collection systems.
 servers:
   - url: /dds
     description: Data Dissemination Service over HTTP  

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -61,10 +61,23 @@ components:
           type: string
         type:
           $ref: "#/components/schemas/dataSourceType"
+        groupingKeys:
+          $ref: "#/components/schemas/groupingKey"
       required:
         - name
-        - type
+        - type      
       additionalProperties: true
+    groupingKey:
+      type: object
+      description: Data Source message element that can be used to organize the the display page.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+      required:
+        - name
+        - description
     knownSourceTypes:
       type: string
       enum: ["GOES", "Iridium", "Network Dcp", "HRIT", "DRGS", "LRGS", "NOAPORT", "WEB"]

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -5,7 +5,7 @@ info:
   description: Defines bare minimum requirements for exchanging 
 servers:
   - url: /dds
-    description: USACE LRGS DDS Server
+    description: Data Dissemination Service over HTTP  
 
 components:
   responses:

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -19,16 +19,34 @@ components:
           schema:
             type: string
   schemas:
-    criteria:
+    searchCriteria:
+      description: Search criteria to use for retrieving messages
       type: object
       properties:
-        medium-id-mask:
+        addresses:
+          type: array
+          items: 
+            type: string
+        address-mask: 
           type: string
-          description: Regular expression to identify what transport medium messages to include
+          description: Regular expression to identify messages by address field if available
+        name-mask:
+          type: string
+          description: Regular expression to identiify message by name field by available
+        names:
+          types: array
+          items:
+            type: string
         since:
           type: string
         until:
           type: string          
+        data-sources:
+          type: array
+          items:
+            type: string
+          description: Which data sources to retrieve data for. (defaults to all data sources)
+        additionalProperties: true
     dcpMessage:
       type: object
       properties:
@@ -123,6 +141,7 @@ paths:
       responses:
         '201':
           description: "Successfully stored."
+          # NOTE: return an identifier
         '400':
           description: "Provided criteria is invalid."
         '500':
@@ -132,7 +151,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/criteria'
+              $ref: '#/components/schemas/searchCriteria'
   /dds/sources:
     get:
       summary: Provide information about data sources available from this instance

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -212,6 +212,7 @@ components:
         timestamp:
           type: string
           format: date-time
+          description: Timestamp the summary was generated (in UTC).
         durationHours:
           type: integer
           description: Duration in hours that the status covers (e.g. 24)

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -229,25 +229,24 @@ components:
               type: integer
         locations:
           type: object
-          additionalProperties:
-            type: object
-            properties:
-              shefId:
-                type: string
-              nessId:
-                type: string
-              status:
-                type: string
-                enum: [missing, partial, parity, complete]
-              messageTotal:
-                type: integer
-                description: Number of messages received
-              parityCount:
-                type: integer
-                description: Number of parity message issues
-              lowBattery:
-                description: List of DCP addresses with low battery status
-                type: boolean
+          additionalProperties: true
+          properties:
+            shefId:
+              type: string
+            nessId:
+              type: string
+            status:
+              type: string
+              enum: [missing, partial, parity, complete]
+            messageTotal:
+              type: integer
+              description: Number of messages received
+            parityCount:
+              type: integer
+              description: Number of parity message issues
+            lowBattery:
+              description: List of DCP addresses with low battery status
+              type: boolean
     
 paths:
   /data/next:

--- a/source/dds-http.yaml
+++ b/source/dds-http.yaml
@@ -4,7 +4,8 @@ info:
   version: '1.0.0'
   description: Defines bare minimum requirements for exchanging 
 servers:
-  - url: http://localhost
+  - url: https://lrgs.usace.army.mil/api
+    description: USACE LRGS DDS Server
 
 components:
   responses:
@@ -19,60 +20,9 @@ components:
           schema:
             type: string
   schemas:
-    searchCriteria:
-      description: Search criteria to use for retrieving messages
-      type: object
-      properties:
-        addresses:
-          type: array
-          items: 
-            type: string
-        address-mask: 
-          type: string
-          description: Regular expression to identify messages by address field if available
-        name-mask:
-          type: string
-          description: Regular expression to identiify message by name field by available
-        names:
-          types: array
-          items:
-            type: string
-        since:
-          type: string
-        until:
-          type: string          
-        data-sources:
-          type: array
-          items:
-            type: string
-          description: Which data sources to retrieve data for. (defaults to all data sources)
-        additionalProperties: true
-    dcpMessage:
-      type: object
-      properties:
-        receiveTime:
-          type: string
-          format: date-time
-        dataSource:
-          $ref: "#/components/schemas/dataSource"
-        data:
-          description: Base64 encoded version of the data. May be text or binary. Messages should
-                       be processed based on the type
-          type: string
-          format: byte
-    dcpMessages:
-      type: object
-      properties:
-        total:
-          type: integer
-          description: Number of messages contained in this result
-        messages:
-          type: array
-          items:
-            $ref: '#/components/schemas/dcpMessage'
     dataSource:
       description: Source of data that this system retrieves messages from.
-                   A given source has a name and type and may provide additional properties as appropriate.
+                  A given source has a name and type and may provide additional properties as appropriate.
       type: object
       properties:
         name:
@@ -85,6 +35,17 @@ components:
         - name
         - type      
       additionalProperties: true
+    knownSourceTypes:
+      type: string
+      enum: ["GOES", "Iridium", "Network Dcp", "HRIT", "DRGS", "LRGS", "NOAPORT", "WEB"]
+    customSourceType:
+      type: string
+    dataSourceType:
+      description: An LRGS generally processes data from specific known sources; however it is possible
+                      for a given installation to retrieve data from custom sources.
+      oneOf:
+        - $ref: '#/components/schemas/knownSourceTypes'
+        - $ref: '#/components/schemas/customSourceType'
     groupingKey:
       type: object
       description: Data Source message element that can be used to organize the the display page.
@@ -96,18 +57,202 @@ components:
       required:
         - name
         - description
-    knownSourceTypes:
-      type: string
-      enum: ["GOES", "Iridium", "Network Dcp", "HRIT", "DRGS", "LRGS", "NOAPORT", "WEB"]
-    customSourceType:
-      type: string
-    dataSourceType:
-      description: An LRGS generally processes data from specific known sources; however it is possible
-                   for a given installation to retrieve data from custom sources.
+    searchCriteria:
+      description: Search criteria to use for retrieving messages
+      type: object
+      additionalProperties: true
+      properties:
+        addresses:
+          type: array
+          items: 
+            type: string
+        address-mask: 
+          type: string
+          description: Regular expression to identify messages by address field if available
+        name-mask:
+          type: string
+          description: Regular expression to identiify message by name field by available
+        names:
+          type: array
+          items:
+            type: string
+        since:
+          type: string
+        until:
+          type: string          
+        data-sources:
+          type: array
+          items:
+            type: string
+          description: Which data sources to retrieve data for. (defaults to all data sources)
+    goesMessage:
+      type: object
+      description: Represents a single message received from a DCP (Data Collection Platform), 
+        including metadata about signal quality, source, and encoded data.
+      properties:
+        receiveTime:
+          type: string
+          format: date-time
+          description: Timestamp when the message was received (in UTC).
+        dataSource:
+          $ref: "#/components/schemas/dataSource"
+        cType:
+          type: string
+          description: Carrier type code (e.g., 'g-s-t').
+        arm:
+          type: string
+          description: Antenna receive mode indicator - Type Message - G=Good,?=Parity Error (Any other is from DAPS)
+        eirp:
+          type: string
+          description: Signal strength, in dB (32-57) - Effective Isotropic Radiated Power (EIRP) value. Good 50 to 38dB.
+        frequency:
+          type: string
+          description: Frequency offset used by the transmitter. +/-X in 50Hz increments (+/-A indicates 500Hz).
+        modulation:
+          type: string
+          description: Modulation type used. High, Normal, Low (H=? 70°, N=60°+/-5°, L=? 50°)
+        quality:
+          type: string
+          description: Data signal quality indicator. Normal, Fair, Poor (Error N<10^-6, Fair>10^-6 to 10^-4, Poor>10^-4)
+        channel:
+          type: string
+          description: Channel number used for transmission (e.g., '162W'). Goes East or West Satellite.
+        downlink:
+          type: string
+          description: Down link status - Hexadecimal coded.
+        charlen:
+          type: integer
+          description: Number of characters in message (includes EOT + FW but not ID).
+        data:
+          type: string
+          description: Raw DCP data payload in plain text format.
+
+    iridiumMessage:
+      type: object
+      description: Message received via Iridium satellite including transmission metadata and DCP payload.
+      properties:
+        receiveTime:
+          type: string
+          format: date-time
+          description: Time the message was received by the system (in UTC).
+        dataSource:
+          $ref: "#/components/schemas/dataSource"
+        imei:
+          type: string
+          description: IMEI identifier extracted from the `ID=` field.
+        timestampOffset:
+          type: string
+          description: Encoded timestamp from `TIME=` field.
+        status:
+          type: string
+          description: Status flag from `STAT=` field.
+        mobileOriginated:
+          type: string
+          description: Message count for mobile-originated packets (MO=).
+        mobileTerminated:
+          type: string
+          description: Message count for mobile-terminated packets (MT=).
+        cdrReference:
+          type: string
+          description: Reference code from `CDR=`.
+        latitude:
+          type: number
+          format: float
+          description: Latitude from `LAT=`.
+        longitude:
+          type: number
+          format: float
+          description: Longitude from `LON=`.
+        radius:
+          type: integer
+          description: Accuracy or coverage radius from `RAD=`.
+        payloadFormat:
+          type: string
+          description: Raw header line preceding DCP payload (e.g. `IE:0200D0`)
+        data:
+          type: string
+          description: DCP data content that follows the header.
+
+    dcpMessage:
       oneOf:
-        - $ref: '#/components/schemas/knownSourceTypes'
-        - $ref: '#/components/schemas/customSourceType'
-        
+        - $ref: '#/components/schemas/goesMessage'
+        - $ref: '#/components/schemas/iridiumMessage'
+      discriminator:
+        propertyName: dataSource.type
+        mapping:
+          GOES: '#/components/schemas/goesMessage'
+          Iridium: '#/components/schemas/iridiumMessage'
+
+    dcpMessages:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Number of messages contained in this result
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/dcpMessage'
+        dataSource:
+          $ref: '#/components/schemas/dataSource'
+        groupingKey:
+          $ref: '#/components/schemas/groupingKey'
+        knownSourceTypes:
+          $ref: '#/components/schemas/knownSourceTypes'
+        customSourceType:
+          $ref: '#/components/schemas/customSourceType'
+        dataSourceType:
+          $ref: '#/components/schemas/dataSourceType'
+
+    statusGroupSummary:
+      type: object
+      description: Summary of DCP statuses for a group of locations
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        durationHours:
+          type: integer
+          description: Duration in hours that the status covers (e.g. 24)
+        counts:
+          type: object
+          properties:
+            missing:
+              type: integer
+            partial:
+              type: integer
+            parity:
+              type: integer
+            complete:
+              type: integer
+            reservoir:
+              type: integer
+        lowBatteryAddresses:
+          type: array
+          items:
+            type: string
+          description: List of DCP addresses with low battery status
+        locations:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              shefId:
+                type: string
+              nessId:
+                type: string
+              status:
+                type: string
+                enum: [missing, partial, parity, complete]
+              messageTotal:
+                type: integer
+                description: Number of messages received
+              parityCount:
+                type: integer
+                description: Number of parity message issues
+              lowBattery:
+                type: boolean
+    
 paths:
   /dds/data/next:
     get:
@@ -165,3 +310,112 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/dataSource"
+        '500':
+          $ref: '#/components/responses/500'
+      tags:
+        - sources
+  /dds/data/query:
+    get:
+      summary: Query DCP messages on the fly
+      description: |
+        Allows direct querying of DCP messages using search criteria fields passed as query parameters.
+        Equivalent to providing a temporary criteria file.
+      parameters:
+        - name: dcpName
+          in: query
+          description: Specific DCP name(s) to filter
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: dcpAddress
+          in: query
+          description: Specific DCP address(es) to filter
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: since
+          in: query
+          description: Lower bound of receive time (UTC)
+          schema:
+            type: string
+            format: date-time
+        - name: until
+          in: query
+          description: Upper bound of receive time (UTC)
+          schema:
+            type: string
+            format: date-time
+        - name: ascending
+          in: query
+          description: Return results in ascending time
+          schema:
+            type: boolean
+        - name: spacecraft
+          in: query
+          description: Satellite selection ('E', 'W', or 'A')
+          schema:
+            type: string
+            enum: [E, W, A]
+        - name: source
+          in: query
+          description: Filter by source types (e.g., GOES, Iridium)
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: single
+          in: query
+          description: Whether to only return a single message
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Matched messages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dcpMessages'
+        '204':
+          description: No messages found matching query.
+        '400':
+          description: Invalid parameters
+        '500':
+          $ref: '#/components/responses/500'
+        '503':
+          $ref: '#/components/responses/503'
+  /dds/data/summary:
+    get:
+      summary: Retrieve status summary for a group
+      description: |
+        Returns a summarized status report for a group of DCP locations, including message counts,
+        parity errors, and battery health.
+      parameters:
+        - name: group
+          in: query
+          required: true
+          description: The name of the group to summarize (e.g., "SWT")
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Status summary for the group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusGroupSummary'
+        '400':
+          description: Missing or invalid group parameter
+        '404':
+          description: Group not implemented or found
+        '500':
+          $ref: '#/components/responses/500'
+        '503':
+          $ref: '#/components/responses/503'


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
The current DDS protocol assume a raw tcp port and requires that our applications directly implement all possible operations and contigiencies. It also makes assumptions about operations that are no longer as practical.

## Solution

I have been describing a pure HTTPS based method of handling LRGS-LRGS/DECODES connection that should make development easier.

- Only Data Transfer is covered directly
- Authentication and Authorization are handled by the implementation (though we will specify some expected standards like using the Authorization header)
- Directly documented is a long-polling method that can work all the way back to HTTP/1.1

TODO/Desired.:
- WebSockets?
- ServerSentEvents

## how you tested the change

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
